### PR TITLE
Correct command for adding pkg globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Yarn caches every package it downloads so it never needs to again. It also paral
 |npm install|yarn <br/> yarn install|Will install packages listed in the `package.json` file|
 |npm install `pkg-name` <br/> npm install --save `pkg-name`| yarn add `pkg-name`|By default Yarn adds the `pgk-name` to `package.json` and `yarn.lock` files|
 |npm install `pkg-name@1.0.0` | yarn add `pgk-name@1.0.0`|
-|npm install `pkg-name` --save-dev| yarn add `pkg-name` --dev|  
-|npm install `pkg-name` --peer| yarn add `pkg-name`--peer|  
-|npm install `pkg-name` --optional| yarn add --optional|  
-|npm install -g `pkg-name`| yarn add global `pkg-name`|
+|npm install `pkg-name` --save-dev| yarn add `pkg-name` --dev|
+|npm install `pkg-name` --peer| yarn add `pkg-name`--peer|
+|npm install `pkg-name` --optional| yarn add --optional|
+|npm install -g `pkg-name`| yarn global add `pkg-name`| Careful, yarn add global `pkg-name` adds packages `global` and `pkg-name` locally! |
 |npm update | yarn upgrade| Note: It's called **upgrade** in yarn|
 |npm uninstall `pkg-name`| yarn remove `pkg-name`|
 |npm run `script-name`| yarn run `script-name`|


### PR DESCRIPTION
Correct the command for installing a package globally using yarn. `yarn add global hotel` added the packages `global` and `hotel` locally for me. Also add a note regarding the same.
Not sure if the behavior was changed recently. I am using yarn `v0.27.5`